### PR TITLE
refactor CHARGE_MODEL var

### DIFF
--- a/examples/building_networks.ipynb
+++ b/examples/building_networks.ipynb
@@ -31,7 +31,9 @@
    "outputs": [],
    "source": [
     "# declare the charge settings and the system you want to generate the network for\n",
-    "CHARGE_MODEL = \"antechamber\" \n",
+    "CHARGE_MODEL = \"antechamber_am1bcc\" \n",
+    "# or\n",
+    "#CHARGE_MODEL = \"openeye_elf10\"\n",
     "SYSTEM_GROUP = \"jacs_set\"\n",
     "SYSTEM_NAME = \"tyk2\""
    ]
@@ -62,7 +64,7 @@
     "network = gufe.LigandNetwork.from_graphml(system_dir.joinpath(\"lomap_network.graphml\").read_text())\n",
     "\n",
     "# load the ligands with charges\n",
-    "supplier = Chem.SDMolSupplier(system_dir.joinpath(f\"ligands_{CHARGE_MODEL}_am1bcc.sdf\"), removeHs=False)\n",
+    "supplier = Chem.SDMolSupplier(system_dir.joinpath(f\"ligands_{CHARGE_MODEL}.sdf\"), removeHs=False)\n",
     "ligands_by_name = {}\n",
     "for mol in supplier:\n",
     "    ofe_mol = gufe.SmallMoleculeComponent.from_rdkit(mol)\n",
@@ -72,7 +74,7 @@
     "protein = gufe.ProteinComponent.from_pdb_file(system_dir.joinpath(\"protein.pdb\").as_posix())\n",
     "\n",
     "# check for cofactors\n",
-    "co_file = system_dir.joinpath(f\"cofactors_{CHARGE_MODEL}_am1bcc.sdf\")\n",
+    "co_file = system_dir.joinpath(f\"cofactors_{CHARGE_MODEL}.sdf\")\n",
     "cofactors = None\n",
     "if co_file.exists():\n",
     "    cofactors = []\n",
@@ -131,7 +133,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "openfe_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -145,9 +147,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I noticed with the way the name convention worked, we need to use:
`CHARGE_MODEL = "antechamber_am1bcc"` or `CHARGE_MODEL = "openeye_elf10"`